### PR TITLE
Add iTunes mappings for movement based on https://help.mp3tag.de/main…

### DIFF
--- a/lib/mp4/MP4TagMapper.ts
+++ b/lib/mp4/MP4TagMapper.ts
@@ -87,6 +87,9 @@ const mp4TagMap: INativeTagMap = {
   '----:com.apple.iTunes:replaygain_track_minmax': 'replaygain_track_minmax',
   '----:com.apple.iTunes:replaygain_album_minmax': 'replaygain_album_minmax',
   '----:com.apple.iTunes:replaygain_undo': 'replaygain_undo',
+  '----:com.apple.iTunes:Movement Name': 'movement',
+  '----:com.apple.iTunes:Movement': 'movementIndex',
+  '----:com.apple.iTunes:Movement Total': 'movementIndex',
   // Additional mappings:
   gnre: 'genre', // ToDo: check mapping
 


### PR DESCRIPTION
Sorry for this unconventional approach, by proposing a PR on your PR.

Based on the mappings found here, I did an attempt to add the iTunes mappings. https://help.mp3tag.de/main_tags.html
Note that I am not 100% this is the way they should me mapped.
