### PR TITLE
Split movementIndex in explicit movementIndex & movementTotal, which …

### DIFF
--- a/lib/common/GenericTagTypes.ts
+++ b/lib/common/GenericTagTypes.ts
@@ -112,6 +112,7 @@ export type GenericTagId =
   | 'keywords'
   | 'movement'
   | 'movementIndex'
+  | 'movementTotal'
   | 'podcastId'
   | 'showMovement'
   | 'stik';
@@ -246,6 +247,7 @@ export const commonTags: ITagInfoMap = {
   keywords: {multiple: true},
   movement: {multiple: false},
   movementIndex: {multiple: false},
+  movementTotal: {multiple: false},
   podcastId: {multiple: false},
   showMovement: {multiple: false},
   stik: {multiple: false}

--- a/lib/common/MetadataCollector.ts
+++ b/lib/common/MetadataCollector.ts
@@ -191,6 +191,10 @@ export class MetadataCollector implements INativeMetadataCollector {
         this.common.disk.of = CommonTagMapper.toIntOrNull(tag.value);
         return;
 
+      case 'movementTotal':
+        this.common.movementIndex.of = CommonTagMapper.toIntOrNull(tag.value);
+        return;
+
       case 'track':
       case 'disk':
       case 'movementIndex':

--- a/lib/mp4/MP4TagMapper.ts
+++ b/lib/mp4/MP4TagMapper.ts
@@ -99,7 +99,7 @@ const mp4TagMap: INativeTagMap = {
   ldes: 'description',
   '©mvn': 'movement',
   '©mvi': 'movementIndex',
-  '©mvc': 'movementIndex',
+  '©mvc': 'movementTotal',
   '©wrk': 'work',
   catg: 'category',
   egid: 'podcastId',
@@ -118,22 +118,5 @@ export class MP4TagMapper extends CaseInsensitiveTagMap {
 
   public constructor() {
     super([tagType],  mp4TagMap);
-  }
-
-  protected postMap(tag: ITag, warnings: INativeMetadataCollector): void {
-    switch (tag.id) {
-      case '©mvi':
-        this.mvi = tag.value;
-        tag.value = `${this.mvi}/${this.mvc}`;
-        break;
-
-      case '©mvc':
-        this.mvc = tag.value;
-        tag.value = `${this.mvi}/${this.mvc}`;
-        break;
-
-      default:
-        break;
-    }
   }
 }


### PR DESCRIPTION
I spitted the movement-total in an explicit `movementTotal` tag.

Sorry, I pointed you in the wrong direction with the prepossessing as this can only handle a single tag.

I think the normalization to a combined object in the generic tag mapper is the way to go. 